### PR TITLE
Fix codesign_build call

### DIFF
--- a/kapew.py
+++ b/kapew.py
@@ -18,7 +18,7 @@ def prep_kolibri_dist(args, remainder):
 
 def codesign_build(args, remainder):
     if sys.platform.startswith('win'):
-        build_tools.build.do_build()
+        build_tools.build.do_build(remainder)
         build_tools.codesigning.codesign_windows_build()
     else:
         if not os.getenv('MAC_CODESIGN_IDENTITY'):


### PR DESCRIPTION
The do_build method requires one argument, this patch fixes the call
done in codesign_build that does the call wihtout any parameters.