### PR TITLE
Catch permission errors creating the (unused?) app files dir, because it blows up Android

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -92,9 +92,11 @@ if pew.ui.platform == "android":
 KOLIBRI_ROOT_URL = 'http://localhost:{}'.format(KOLIBRI_PORT)
 os.environ["DJANGO_SETTINGS_MODULE"] = "kolibri.deployment.default.settings.base"
 
-app_data_dir = pew.get_app_files_dir()
-os.makedirs(app_data_dir, exist_ok=True)
-
+try:
+    os.makedirs(pew.get_app_files_dir(), exist_ok=True)
+except PermissionError:
+    pass
+    
 if not 'KOLIBRI_HOME' in os.environ:
     kolibri_home = os.path.join(os.path.expanduser("~"), ".kolibri")
 


### PR DESCRIPTION
```
07-31 02:41:33.773  5953  6059 I python  : Traceback (most recent call last
07-31 02:41:33.773  5953  6059 I python  :   File "/home/kivy/build/android/main.py", line 96, in <module
07-31 02:41:33.775  5953  6059 I python  :   File "/home/kivy/.local/share/python-for-android/build/other_builds/python3/armeabi-v7a__ndk_target_21/python3/Lib/os.py", line 221, in makedirs
07-31 02:41:33.776  5953  6059 I python  : PermissionError: [Errno 13] Permission denied: '/storage/self/primary/.kolibri
07-31 02:41:33.776  5953  6059 I python  : Python for android ended
```