### PR TITLE
Sets minimum size for app window

### DIFF
--- a/src/kolibri_app/view.py
+++ b/src/kolibri_app/view.py
@@ -51,6 +51,7 @@ class KolibriView(object):
         self.current_url = None
 
         self.view = wx.Frame(None, -1, APP_NAME, size=size)
+        self.view.SetMinSize((350, 400))
 
         backend = html2.WebViewBackendDefault
 


### PR DESCRIPTION
Using [SetMinSize](https://docs.wxpython.org/wx.Window.html#wx.Window.SetMinSize), the minimum size on the top-level window `wx.Frame` is set so that it does not allow the frame to be resized below the size entered.

https://user-images.githubusercontent.com/46411498/232567447-6307e195-73f4-4187-beab-a397df1cfee6.mp4

