### PR TITLE
Fix invocation of base64 command.

### DIFF
--- a/.github/workflows/build_mac.yml
+++ b/.github/workflows/build_mac.yml
@@ -112,7 +112,7 @@ jobs:
         security create-keychain -p "$KEYCHAIN_PASSWORD" temp.keychain
         security set-keychain-settings -lut 21600 temp.keychain
         security unlock-keychain -p "$KEYCHAIN_PASSWORD" temp.keychain
-        echo -n "${{ secrets.KOLIBRI_MAC_APP_CERTIFICATE }}" | base64 --decode --output certificate.p12
+        echo -n "${{ secrets.KOLIBRI_MAC_APP_CERTIFICATE }}" | base64 --decode --output=certificate.p12
         # -A option allows any application to read keys.
         # This would be insecure if the keychain was retained but GitHub action
         # VMs are thrown away after use.

--- a/src/kolibri_app/__init__.py
+++ b/src/kolibri_app/__init__.py
@@ -4,7 +4,7 @@ from kolibri.main import enable_plugin
 
 from kolibri_app.constants import MAC
 
-__version__ = "0.4.1"
+__version__ = "0.4.2"
 
 os.environ["KOLIBRI_INSTALLER_VERSION"] = __version__
 


### PR DESCRIPTION
Fixes issue with base64 command that only became apparent on macos13.
Updates version to 0.4.2

This does indeed seem to fix it:

https://github.com/learningequality/kolibri-app/actions/runs/8916002245