### PR TITLE
Add certifi to hidden imports to ensure its resources get gathered.

### DIFF
--- a/hooks/hook-kolibri.py
+++ b/hooks/hook-kolibri.py
@@ -140,7 +140,8 @@ def datas_filter(item):
     return True
 
 
-hiddenimports = collect_submodules("kolibri", submodule_filter)
+# Collect certifi explicitly because it does not get added otherwise.
+hiddenimports = collect_submodules("kolibri", submodule_filter) + ["certifi"]
 
 datas = []
 


### PR DESCRIPTION
Hopefully fixes [#126](https://github.com/learningequality/kolibri-app/issues/126)