### PR TITLE
Always run the PR build on PRs

### DIFF
--- a/.github/workflows/build_mac.yml
+++ b/.github/workflows/build_mac.yml
@@ -61,7 +61,7 @@ jobs:
     - name: Validate whl reference inputs
       if: ${{ (inputs.whl-file-name && inputs.whl-url) || (!inputs.whl-file-name && !inputs.whl-url) }}
       run: |
-        echo "Must specify exactly one reference for the whl file to build the EXE with."
+        echo "Must specify exactly one reference for the whl file to build the DMG with."
         exit 1
     - uses: actions/checkout@v4
       if: ${{ !inputs.ref }}

--- a/.github/workflows/pr_build.yml
+++ b/.github/workflows/pr_build.yml
@@ -6,20 +6,7 @@ on:
     - main
 
 jobs:
-  pre_job:
-    name: Path match check
-    runs-on: ubuntu-latest
-    # Map a step output to a job output
-    outputs:
-      should_skip: ${{ steps.skip_check.outputs.should_skip }}
-    steps:
-      - id: skip_check
-        uses: fkirc/skip-duplicate-actions@master
-        with:
-          github_token: ${{ github.token }}
   latest_kolibri_release:
-    needs: pre_job
-    if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
     runs-on: ubuntu-latest
     outputs:
       whl-url: ${{ steps.get_latest_kolibri_release.outputs.result }}
@@ -45,8 +32,7 @@ jobs:
 
   build_dmg:
     name: Build Unsigned DMG
-    needs: [pre_job, latest_kolibri_release]
-    if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
+    needs: latest_kolibri_release
     uses: ./.github/workflows/build_mac.yml
     with:
       whl-url: ${{ needs.latest_kolibri_release.outputs.whl-url }}


### PR DESCRIPTION
## Summary
* Removes any path checking, as almost any path will change the asset