### PR TITLE
Separate UI and server into two processes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,11 @@ setup(
     include_package_data=True,
     zip_safe=True,
     license="MIT",
-    install_requires=["wxPython==4.2.2", "cryptography==45.0.4", "cffi==1.14.4"],
+    install_requires=[
+        "wxPython==4.2.2",
+        "cryptography==45.0.3",
+        "cffi==1.14.4",
+        "pywin32==310; sys_platform == 'win32'",
+    ],
     extras_require={"dev": ["pre-commit"]},
 )

--- a/src/kolibri_app/__init__.py
+++ b/src/kolibri_app/__init__.py
@@ -1,7 +1,5 @@
 import os
 
-from kolibri.main import enable_plugin
-
 from kolibri_app.constants import MAC
 
 __version__ = "0.4.4"
@@ -12,5 +10,3 @@ if MAC:
     os.environ["KOLIBRI_INSTALLATION_TYPE"] = "mac"
 
 os.environ["DJANGO_SETTINGS_MODULE"] = "kolibri_app.django_app_settings"
-enable_plugin("kolibri.plugins.app")
-enable_plugin("kolibri_app")

--- a/src/kolibri_app/__main__.py
+++ b/src/kolibri_app/__main__.py
@@ -7,8 +7,18 @@ from kolibri_app.application import KolibriApp
 from kolibri_app.constants import WINDOWS
 from kolibri_app.logger import logging
 
+if WINDOWS:
+    from kolibri_app.server_process import ServerProcess
+
 
 def main():
+    # This block is the entry point for the server subprocess
+    if WINDOWS and "--run-as-server" in sys.argv:
+        logging.info("Starting in server mode...")
+        server = ServerProcess()
+        server.run()
+        sys.exit(0)
+
     if WINDOWS:
         import winreg
 

--- a/src/kolibri_app/application.py
+++ b/src/kolibri_app/application.py
@@ -1,38 +1,28 @@
+import atexit
 import json
 import os
 import webbrowser
-from threading import Thread
 
 import wx
-from kolibri.main import initialize
-from kolibri.plugins.app.utils import interface
-from kolibri.plugins.app.utils import SHARE_FILE
+from kolibri.main import enable_plugin
 from kolibri.utils.conf import KOLIBRI_HOME
-from kolibri.utils.conf import OPTIONS
-from kolibri.utils.server import KolibriProcessBus
-from magicbus.plugins import SimplePlugin
 
 from kolibri_app.constants import APP_NAME
+from kolibri_app.constants import WINDOWS
 from kolibri_app.logger import logging
 from kolibri_app.view import KolibriView
 
+if WINDOWS:
+    from kolibri_app.server_manager_windows import WindowsServerManager as ServerManager
+else:
+    from kolibri_app.server_manager_posix import PosixServerManager as ServerManager
+    from kolibri.plugins.app.utils import interface
 
-share_file = None
 
 STATE_FILE = "app_state.json"
 
 # State keys
 URL = "URL"
-
-
-class AppPlugin(SimplePlugin):
-    def __init__(self, bus, callback):
-        self.bus = bus
-        self.callback = callback
-        self.bus.subscribe("SERVING", self.SERVING)
-
-    def SERVING(self, port):
-        self.callback(port)
 
 
 class KolibriApp(wx.App):
@@ -48,13 +38,17 @@ class KolibriApp(wx.App):
         if self._checker.IsAnotherRunning():
             return True
 
+        enable_plugin("kolibri.plugins.app")
+        enable_plugin("kolibri_app")
+
         self.windows = []
+        self.kolibri_origin = None
+
+        self.server_manager = ServerManager(self)
+
         self.create_kolibri_window()
 
-        # start server
-        self.server_thread = None
-        self.kolibri_server = None
-        self.kolibri_origin = None
+        atexit.register(self.cleanup_on_exit)
         self.start_server()
 
         return True
@@ -66,30 +60,14 @@ class KolibriApp(wx.App):
         return None
 
     def start_server(self):
-        if self.server_thread:
-            return
-
-        logging.info("Preparing to start Kolibri server")
-        self.server_thread = Thread(target=self.start_kolibri_server)
-        self.server_thread.daemon = True
-        self.server_thread.start()
-
-    def start_kolibri_server(self):
-        initialize()
-
-        if callable(share_file):
-            interface.register_capabilities(**{SHARE_FILE: share_file})
-        self.kolibri_server = KolibriProcessBus(
-            port=OPTIONS["Deployment"]["HTTP_PORT"],
-            zip_port=OPTIONS["Deployment"]["ZIP_CONTENT_PORT"],
-        )
-        app_plugin = AppPlugin(self.kolibri_server, self.load_kolibri)
-        app_plugin.subscribe()
-        self.kolibri_server.run()
+        self.server_manager.start()
 
     def shutdown(self):
-        if self.kolibri_server is not None:
-            self.kolibri_server.transition("EXITED")
+        self.server_manager.shutdown()
+
+    def cleanup_on_exit(self):
+        """Cleanup function called on app exit."""
+        self.shutdown()
 
     def create_kolibri_window(self, url=None):
         window = KolibriView(self, url=url)
@@ -121,7 +99,7 @@ class KolibriApp(wx.App):
     def save_state(self, view=None):
         try:
             state = {}
-            if view:
+            if view and view.get_url():
                 state[URL] = view.get_url()
             with open(
                 os.path.join(KOLIBRI_HOME, STATE_FILE), "w", encoding="utf-8"
@@ -130,7 +108,7 @@ class KolibriApp(wx.App):
         except (IOError, ValueError):
             return {}
 
-    def load_kolibri(self, listen_port):
+    def load_kolibri(self, listen_port, root_url=None):
         self.kolibri_origin = "http://localhost:{}".format(listen_port)
 
         # Check for saved URL, which exists when the app was put to sleep last time it ran
@@ -142,7 +120,14 @@ class KolibriApp(wx.App):
         if URL in saved_state and saved_state[URL].startswith(self.kolibri_origin):
             next_url = saved_state[URL]
 
-        root_url = self.kolibri_origin + interface.get_initialize_url(next_url)
-        logging.info("root_url = {}".format(root_url))
+        if root_url:
+            # On Windows, root_url is provided by the server process
+            final_url = f"{root_url}?next={next_url}" if next_url else root_url
+        else:
+            # On other platforms, we construct the URL ourselves
+            final_url = self.kolibri_origin + interface.get_initialize_url(
+                next_url=next_url
+            )
+        logging.info(f"Loading Kolibri at: {final_url}")
 
-        wx.CallAfter(self.view.load_url, root_url)
+        wx.CallAfter(self.view.load_url, final_url)

--- a/src/kolibri_app/server_manager_posix.py
+++ b/src/kolibri_app/server_manager_posix.py
@@ -1,0 +1,60 @@
+from threading import Thread
+
+from kolibri.main import initialize
+from kolibri.plugins.app.utils import interface
+from kolibri.plugins.app.utils import SHARE_FILE
+from kolibri.utils.conf import OPTIONS
+from kolibri.utils.server import KolibriProcessBus
+from magicbus.plugins import SimplePlugin
+
+from kolibri_app.logger import logging
+
+share_file = None
+
+
+class AppPlugin(SimplePlugin):
+    def __init__(self, bus, callback):
+        self.bus = bus
+        self.callback = callback
+        self.bus.subscribe("SERVING", self.SERVING)
+
+    def SERVING(self, port):
+        self.callback(port, root_url=None)
+
+
+class PosixServerManager:
+    """
+    Manages the Kolibri server for non-Windows platforms (macOS, Linux)
+    by running it in a separate thread within the same process.
+    """
+
+    def __init__(self, app):
+        self.app = app
+        self.kolibri_server = None
+        self.server_thread = None
+
+    def start(self):
+        if self.server_thread:
+            return
+
+        logging.info("Preparing to start Kolibri server thread")
+        self.server_thread = Thread(target=self._run_kolibri_server)
+        self.server_thread.daemon = True
+        self.server_thread.start()
+
+    def _run_kolibri_server(self):
+        initialize()
+
+        if callable(share_file):
+            interface.register_capabilities(**{SHARE_FILE: share_file})
+        self.kolibri_server = KolibriProcessBus(
+            port=OPTIONS["Deployment"]["HTTP_PORT"],
+            zip_port=OPTIONS["Deployment"]["ZIP_CONTENT_PORT"],
+        )
+        app_plugin = AppPlugin(self.kolibri_server, self.app.load_kolibri)
+        app_plugin.subscribe()
+        self.kolibri_server.run()
+
+    def shutdown(self):
+        if self.kolibri_server is not None:
+            self.kolibri_server.transition("EXITED")

--- a/src/kolibri_app/server_manager_windows.py
+++ b/src/kolibri_app/server_manager_windows.py
@@ -1,0 +1,305 @@
+"""Windows Server Manager - UI Process Side
+
+This module manages the Kolibri server subprocess on Windows from the main UI process.
+It handles:
+- Server subprocess lifecycle management with Job Objects for cleanup
+- Named pipe IPC client communication with server subprocess
+- Pull-based server readiness handshake to avoid race conditions
+- Subprocess output logging and error handling
+
+Architecture Overview:
+- Spawns server subprocess with --run-as-server flag
+- Uses Windows Job Objects to ensure subprocess cleanup on UI process exit
+- Named pipe client connects to server and requests connection info
+- Server responds with port and URL when Kolibri is fully initialized
+- Handles subprocess crashes and pipe disconnections gracefully
+"""
+import json
+import os
+import subprocess
+import sys
+import time
+from threading import Event
+from threading import Thread
+
+import pywintypes
+import win32api
+import win32con
+import win32file
+import win32job
+import win32pipe
+import winerror
+import wx
+from kolibri.utils.conf import KOLIBRI_HOME
+
+from kolibri_app.logger import logging
+
+
+# Named pipe for IPC between UI process and server subprocess
+PIPE_NAME = r"\\.\pipe\KolibriAppServerIPC"
+
+
+class WindowsServerManager:
+    """
+    Manages the Kolibri server subprocess and IPC communication for Windows.
+    Uses Job Objects to prevent zombie processes and named pipes for communication.
+    """
+
+    def __init__(self, app):
+        self.app = app
+        self.server_process = None
+        self.job_handle = None  # Windows Job Object handle for subprocess cleanup
+
+        # Named pipe IPC client state
+        self.pipe_handle = None
+        self.pipe_reader_thread = None
+        self.pipe_shutdown_event = Event()
+
+    def start(self):
+        """
+        Start the Kolibri server subprocess and IPC communication.
+        Pipe client starts first to avoid timing issues.
+        """
+        if self.server_process:
+            return
+
+        logging.info("Preparing to start Kolibri server process")
+        self.start_pipe_client()
+        self._launch_server_process()
+
+    def shutdown(self):
+        """
+        Clean shutdown of server subprocess and IPC communication.
+        Job Object provides additional safety for subprocess cleanup.
+        """
+        if self.server_process and self.server_process.poll() is None:
+            logging.info("Shutting down server process...")
+            try:
+                # Attempt graceful shutdown first - Job Object provides backup cleanup
+                self.server_process.terminate()
+                self.server_process.wait(timeout=10)
+            except subprocess.TimeoutExpired:
+                logging.warning(
+                    "Server process did not terminate gracefully, forcing kill..."
+                )
+                self.server_process.kill()
+                self.server_process.wait()
+            except Exception as e:
+                logging.error(f"Error shutting down server process: {e}")
+
+        # Stop pipe communication thread
+        if self.pipe_reader_thread and self.pipe_reader_thread.is_alive():
+            logging.info("Stopping pipe reader thread...")
+            self.pipe_shutdown_event.set()
+            if self.pipe_handle:
+                # Close pipe handle to unblock any pending ReadFile calls
+                win32file.CloseHandle(self.pipe_handle)
+                self.pipe_handle = None
+            self.pipe_reader_thread.join(timeout=2)
+
+        # Clean up Job Object handle
+        if self.job_handle:
+            try:
+                win32api.CloseHandle(self.job_handle)
+                self.job_handle = None
+                logging.info("Closed job object handle.")
+            except Exception as e:
+                logging.error(f"Error closing job object handle: {e}")
+
+    def _launch_server_process(self):
+        """
+        Launch the Kolibri server subprocess with Job Object management.
+        Job Objects provide automatic cleanup to prevent zombie processes.
+        """
+        # Set up Job Object for automatic subprocess cleanup
+        try:
+            self.job_handle = win32job.CreateJobObject(None, "")
+
+            # Query current job limits to modify them
+            extended_info = win32job.QueryInformationJobObject(
+                self.job_handle, win32job.JobObjectExtendedLimitInformation
+            )
+
+            # Configure job to terminate all processes when the job handle closes
+            # This happens automatically when the UI process exits
+            extended_info["BasicLimitInformation"][
+                "LimitFlags"
+            ] = win32job.JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE
+            win32job.SetInformationJobObject(
+                self.job_handle,
+                win32job.JobObjectExtendedLimitInformation,
+                extended_info,
+            )
+        except Exception as e:
+            logging.error(
+                f"Failed to create or configure job object: {e}", exc_info=True
+            )
+            self.job_handle = None
+
+        # Launch the server subprocess
+        try:
+            # Build command line - detect PyInstaller bundle vs development mode
+            if getattr(sys, "frozen", False):
+                # PyInstaller bundle mode - use current executable with server flag
+                cmd = [sys.executable, "--run-as-server"]
+            else:
+                # Development mode - run as Python module
+                cmd = [sys.executable, "-m", "kolibri_app", "--run-as-server"]
+
+            env = os.environ.copy()
+            env["KOLIBRI_HOME"] = os.environ.get("KOLIBRI_HOME", KOLIBRI_HOME)
+            env["DJANGO_SETTINGS_MODULE"] = "kolibri_app.django_app_settings"
+            logging.info(f"Launching server subprocess: {' '.join(cmd)}")
+
+            # Configure subprocess to run with hidden console window
+            startupinfo = subprocess.STARTUPINFO()
+            startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
+
+            # Launch subprocess with stdout/stderr pipes for logging
+            self.server_process = subprocess.Popen(
+                cmd,
+                env=env,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                startupinfo=startupinfo,
+            )
+
+            # Start background threads to forward subprocess output to application logging
+            Thread(
+                target=self._log_subprocess_output,
+                args=(self.server_process.stdout, "stdout"),
+                daemon=True,
+            ).start()
+            Thread(
+                target=self._log_subprocess_output,
+                args=(self.server_process.stderr, "stderr"),
+                daemon=True,
+            ).start()
+
+            # Assign subprocess to Job Object for automatic cleanup
+            if self.job_handle:
+                try:
+                    proc_handle = win32api.OpenProcess(
+                        win32con.PROCESS_ALL_ACCESS, False, self.server_process.pid
+                    )
+                    win32job.AssignProcessToJobObject(self.job_handle, proc_handle)
+                    logging.info(
+                        f"Successfully assigned server process (PID: {self.server_process.pid}) to job object."
+                    )
+                except Exception as e:
+                    logging.error(
+                        f"Failed to assign process to job object: {e}", exc_info=True
+                    )
+
+        except Exception as e:
+            logging.error(f"Failed to launch server process: {e}", exc_info=True)
+            wx.MessageBox(
+                f"Failed to start Kolibri server: {e}", "Error", wx.OK | wx.ICON_ERROR
+            )
+
+    def _log_subprocess_output(self, pipe, pipe_name):
+        """
+        Forward subprocess stdout/stderr to application logging system.
+        """
+        try:
+            for line in iter(pipe.readline, b""):
+                if line:
+                    # Forward subprocess output to main application logging
+                    logging.info(
+                        f"Server {pipe_name}: {line.decode('utf-8', errors='replace').strip()}"
+                    )
+        finally:
+            pipe.close()
+
+    def start_pipe_client(self):
+        """
+        Start the named pipe client thread for IPC communication.
+        Handles pipe connection, server info requests, and reconnection.
+        """
+        if self.pipe_reader_thread and self.pipe_reader_thread.is_alive():
+            return
+        logging.info("Starting pipe client reader thread...")
+        self.pipe_shutdown_event.clear()
+        self.pipe_reader_thread = Thread(
+            target=self._pipe_reader_thread_func, daemon=True
+        )
+        self.pipe_reader_thread.start()
+
+    def _pipe_reader_thread_func(self):
+        """
+        Named pipe client thread main loop.
+        Implements pull-based server readiness handshake to avoid race conditions.
+        """
+        while not self.pipe_shutdown_event.is_set():
+            try:
+                # Block until the server subprocess creates the named pipe
+                win32pipe.WaitNamedPipe(PIPE_NAME, win32pipe.NMPWAIT_WAIT_FOREVER)
+
+                self.pipe_handle = win32file.CreateFile(
+                    PIPE_NAME,
+                    win32file.GENERIC_READ | win32file.GENERIC_WRITE,
+                    0,
+                    None,
+                    win32file.OPEN_EXISTING,
+                    0,
+                    None,
+                )
+
+                logging.info("Connected to named pipe.")
+
+                # Immediately request server connection information (pull-based handshake)
+                self._send_pipe_message({"type": "request_server_info"})
+
+                # Message processing loop for connected pipe
+                while not self.pipe_shutdown_event.is_set():
+                    hr, data = win32file.ReadFile(self.pipe_handle, 4096)
+                    if hr == winerror.ERROR_SUCCESS or hr == winerror.ERROR_MORE_DATA:
+                        message = json.loads(data.decode("utf-8"))
+                        logging.debug(f"Pipe client received message: {message}")
+                        wx.CallAfter(self._handle_pipe_message, message)
+                    else:
+                        # Pipe closed by server - break inner loop to reconnect
+                        break
+
+            except pywintypes.error as e:
+                if (
+                    e.winerror == winerror.ERROR_FILE_NOT_FOUND
+                    or e.winerror == winerror.ERROR_BROKEN_PIPE
+                ):
+                    logging.info("Pipe not available or broken, will retry...")
+                else:
+                    logging.error(f"Pipe error: {e}")
+                # Clean up pipe handle before retry
+                if self.pipe_handle:
+                    win32file.CloseHandle(self.pipe_handle)
+                    self.pipe_handle = None
+                time.sleep(2)  # Delay before retry to avoid busy loop
+            except Exception as e:
+                logging.error(f"Error in pipe reader thread: {e}", exc_info=True)
+                time.sleep(2)
+
+    def _handle_pipe_message(self, message):
+        """
+        Handle messages received from server subprocess via named pipe.
+        Runs on main UI thread and processes server responses.
+        """
+        msg_type = message.get("type")
+        if msg_type == "server_ready":
+            port = message["port"]
+            root_url = message["root_url"]
+            logging.info(f"Server is ready on port {port}. Loading URL.")
+            self.app.load_kolibri(port, root_url)
+
+    def _send_pipe_message(self, message):
+        """
+        Send JSON message to server subprocess via named pipe.
+        """
+        if self.pipe_handle:
+            try:
+                # Encode message as JSON and send to server subprocess
+                encoded_message = json.dumps(message).encode("utf-8")
+                win32file.WriteFile(self.pipe_handle, encoded_message)
+            except pywintypes.error as e:
+                logging.error(f"Failed to send message via pipe: {e}")
+        else:
+            logging.warning("Cannot send message, pipe not connected.")

--- a/src/kolibri_app/server_process.py
+++ b/src/kolibri_app/server_process.py
@@ -1,0 +1,218 @@
+"""Windows Server Subprocess Implementation
+
+This module implements the Kolibri server that runs as a separate subprocess on Windows.
+It handles:
+- Named pipe IPC communication with the main UI process
+- Server lifecycle management and readiness signaling
+- PyInstaller compatibility for bundled executables
+
+Architecture Overview:
+- Main UI process spawns this as subprocess with --run-as-server flag
+- Server initializes Kolibri and starts listening on available port
+- Named pipe server accepts connections from UI process
+- Pull-based handshake: UI requests server info when ready
+- Server responds with port and initialization URL
+"""
+import json
+import os
+import sys
+import time
+from threading import Event
+from threading import Thread
+
+import pywintypes
+import win32file
+import win32pipe
+import winerror
+
+# Fix Python path for PyInstaller builds
+if getattr(sys, "frozen", False) and hasattr(sys, "_MEIPASS"):
+    sys.path.insert(0, os.path.join(sys._MEIPASS, "kolibrisrc"))
+    sys.path.insert(0, os.path.join(sys._MEIPASS, "kolibrisrc", "kolibri", "dist"))
+
+from kolibri.main import initialize, enable_plugin
+from kolibri.plugins.app.utils import interface, SHARE_FILE
+from kolibri.utils.conf import OPTIONS
+from kolibri.utils.server import KolibriProcessBus
+from kolibri_app.logger import logging
+
+# File sharing disabled to mirror original implementation
+share_file = None
+
+# Named pipe for IPC between UI process and server subprocess
+# Uses Windows named pipe format: \\.<hostname>\pipe\<pipename>
+PIPE_NAME = r"\\.\pipe\KolibriAppServerIPC"
+
+
+class PipeServerThread(Thread):
+    """
+    Manages named pipe server communication in a dedicated thread.
+    Handles client connections, processes messages, and maintains IPC until shutdown.
+    """
+
+    def __init__(self, server_process):
+        super().__init__(daemon=True)
+        self.server_process = server_process
+        self.pipe = None
+
+    def run(self):
+        """Main pipe server loop - handles client connections and message processing."""
+        logging.info("Pipe server thread started.")
+        while not self.server_process.shutdown_event.is_set():
+            self.pipe = None
+            try:
+                # Create named pipe with message mode for structured communication
+                self.pipe = win32pipe.CreateNamedPipe(
+                    PIPE_NAME,
+                    win32pipe.PIPE_ACCESS_DUPLEX,
+                    win32pipe.PIPE_TYPE_MESSAGE
+                    | win32pipe.PIPE_READMODE_MESSAGE
+                    | win32pipe.PIPE_WAIT,
+                    win32pipe.PIPE_UNLIMITED_INSTANCES,
+                    65536,
+                    65536,
+                    0,
+                    None,
+                )
+
+                logging.info(f"Named pipe '{PIPE_NAME}' created. Waiting for client...")
+                # Block until a client connects to the pipe
+                win32pipe.ConnectNamedPipe(self.pipe, None)
+                logging.info("Client connected to named pipe.")
+
+                # Message processing loop for connected client
+                while not self.server_process.shutdown_event.is_set():
+                    hr, data = win32file.ReadFile(self.pipe, 4096)
+                    if hr != winerror.ERROR_SUCCESS and hr != winerror.ERROR_MORE_DATA:
+                        break
+
+                    # Parse JSON message from client
+                    message = json.loads(data.decode("utf-8"))
+                    logging.debug(f"Pipe server received message: {message}")
+
+                    # Handle server info requests (part of startup handshake)
+                    if message.get("type") == "request_server_info":
+                        self.server_process.handle_server_info_request()
+
+            except pywintypes.error as e:
+                if e.winerror == winerror.ERROR_PIPE_BUSY:
+                    logging.warning("Pipe is busy, retrying...")
+                    time.sleep(1)
+                elif e.winerror == winerror.ERROR_BROKEN_PIPE:
+                    logging.info("Client disconnected.")
+                else:
+                    logging.error(f"Pipe server error: {e}", exc_info=True)
+            except Exception as e:
+                logging.error(
+                    f"Unhandled error in pipe server thread: {e}", exc_info=True
+                )
+            finally:
+                if self.pipe:
+                    win32file.CloseHandle(self.pipe)
+                    self.pipe = None
+        logging.info("Pipe server thread finished.")
+
+    def send_message(self, message):
+        """Send JSON message to connected client."""
+        if not self.pipe:
+            logging.warning("Cannot send message, pipe not connected.")
+            return
+
+        try:
+            # Encode message as JSON and send via pipe
+            encoded_message = json.dumps(message).encode("utf-8")
+            win32file.WriteFile(self.pipe, encoded_message)
+        except pywintypes.error as e:
+            if e.winerror == winerror.ERROR_BROKEN_PIPE:
+                logging.info("Client disconnected, cannot send message.")
+            else:
+                raise
+
+
+class ServerProcess:
+    """
+    Main server process coordinator for Windows subprocess implementation.
+    Manages server initialization, named pipe communication, and handshake coordination.
+    """
+
+    def __init__(self):
+        # Shutdown coordination between threads
+        self.shutdown_event = Event()
+        self.kolibri_server = None
+
+        # Named pipe communication thread
+        self.pipe_server_thread = None
+
+        # Server readiness coordination for startup handshake
+        # These are set when Kolibri server starts and used to respond to client requests
+        self.server_ready_event = Event()
+        self.ready_port = None
+        self.ready_root_url = None
+
+    def on_server_start(self, port):
+        """
+        Callback invoked when Kolibri server starts.
+        Prepares connection details for UI process handshake.
+        """
+        logging.info(f"Server is running on port {port}. Ready for client requests.")
+
+        # Build the complete initialization URL for the UI process
+        kolibri_origin = f"http://localhost:{port}"
+        root_url = kolibri_origin + interface.get_initialize_url()
+
+        self.ready_port = port
+        self.ready_root_url = root_url
+        self.server_ready_event.set()
+
+    def handle_server_info_request(self):
+        """
+        Handle server info request from UI process.
+        Implements pull-based readiness pattern to avoid race conditions.
+        """
+        # Wait for Kolibri server to complete initialization
+        if self.server_ready_event.wait(timeout=60):
+            # Send connection details to UI process
+            payload = {
+                "type": "server_ready",
+                "port": self.ready_port,
+                "root_url": self.ready_root_url,
+            }
+            logging.info("Client requested server info, sending ready response.")
+            self.pipe_server_thread.send_message(payload)
+        else:
+            logging.error(
+                "Server info was requested, but server failed to become ready in time."
+            )
+
+    def run(self):
+        """
+        Main server process entry point - initializes and runs Kolibri server.
+        The server runs until terminated by the Job Object or explicit shutdown.
+        """
+        try:
+            logging.info("Server process: Initializing Kolibri...")
+            enable_plugin("kolibri.plugins.app")
+            initialize()
+
+            # Start IPC communication thread
+            self.pipe_server_thread = PipeServerThread(self)
+            self.pipe_server_thread.start()
+
+            # File sharing integration - intentionally disabled to mirror original implementation
+            # This check will always be False since share_file is None
+            if callable(share_file):
+                interface.register_capabilities(**{SHARE_FILE: share_file})
+
+            # Create Kolibri server instance
+            self.kolibri_server = KolibriProcessBus(
+                port=OPTIONS["Deployment"]["HTTP_PORT"],
+                zip_port=OPTIONS["Deployment"]["ZIP_CONTENT_PORT"],
+            )
+            self.kolibri_server.subscribe("SERVING", self.on_server_start)
+
+            logging.info("Server process: Starting Kolibri server...")
+            # Start serving - this blocks until shutdown
+            self.kolibri_server.run()
+        except Exception as e:
+            logging.error(f"Server process error: {e}", exc_info=True)
+            sys.exit(1)


### PR DESCRIPTION
## Summary

This pull request refactors the Kolibri Windows application to use a two-process architecture, separating the UI from the Kolibri server. This is the first step in a larger effort to modernize the Windows installer and application behavior.

### Explanation of core changes (Windows):

1.  **Process Separation (UI vs. Server):**
    * **What:** The main application (`kolibri_app`) now acts as a lightweight UI process, responsible only for the `wxPython` window and webview. It spawns the Kolibri server as a separate, hidden child subprocess using the same executable but with a new `--run-as-server` flag.

2.  **Robust Lifecycle Management with Job Objects:**
    * **What:** On launch, the UI process creates a Windows **Job Object** and assigns the server subprocess to it.
    * **Why:** The Job Object is configured with `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE`. That way, if the main UI process is closed or crashes, the operating system will terminate the server subprocess. This prevents orphaned or "zombie" Kolibri processes from being left behind.

3.  **Reliable Startup Handshake with Named Pipes:**
    * **What:** A **pull-based** Inter-Process Communication (IPC) mechanism using **Named Pipes**.
        1.  The UI process starts its named pipe client and tries to connect.
        2.  It launches the server process.
        3.  The server process creates the named pipe server and waits for a connection.
        4.  Once connected, the UI client sends a `request_server_info` message.
        5.  The server only responds with the port and URL after the Kolibri backend is fully initialized and ready to serve requests.
    * **Why:** This pull-based handshake is important for avoiding race conditions. The UI waits for an explicit signal, ensuring that the first URL loaded is always valid and the server is prepared to handle it.

The existing in-process, thread-based behavior for macOS and Linux is preserved and refactored into `server_manager_posix.py` to ensure no regressions on those platforms.


### Code Pointers
- **src/kolibri_app/application.py**: The central integration point. Note the conditional import of `WindowsServerManager` and `PosixServerManager` and how `start_server()` and `shutdown()` direct to the appropriate manager based on the OS.
- **src/kolibri_app/server_manager_windows.py**: **(UI Process Logic)** Contains the client-side code for Windows. This file is responsible for launching the subprocess, creating and managing the Job Object, and handling the named pipe client communication.
- **src/kolibri_app/server_process.py**: **(Server Process Logic)** This is the new entry point for the server subprocess (`--run-as-server`). It initializes Kolibri and manages the named pipe server, responding to requests from the UI process.
- **src/kolibri_app/__main__.py**: Note the new argument parsing at the top of `main()` that routes execution to `ServerProcess` when the `--run-as-server` flag is present.


## References

Partially fixes #167, concerning the UI/Server Process seperation for Windows.

## Reviewer guidance

The most critical area for review is the new Windows-specific logic.

**How to test on Windows:**
1.  Install dependencies again, (`make dependencies`).
2. Run 
```
make get-whl whl="https://github.com/learningequality/kolibri/releases/download/v0.18.1/kolibri-0.18.1-py2.py3-none-any.whl"
```
3.  Run `make pyinstaller` to build the application.
4.  Run the executable located in `dist/Kolibri-0.18.1/Kolibri-0.18.1.exe`.

**Primary focus for testing:**
- **Standard Startup & Shutdown:**
    1. Launch the app. Does the UI appear and show the loading screen?
    2. Does the Kolibri interface load successfully without errors?
    3. Close the main application window.
    4. Open Task Manager and confirm that the `Kolibri-0.18.1.exe` and `Kolibri` processes terminate completely within a few seconds. There should be no lingering processes.

- **Robustness Test (Process Crash Simulation):**
	1. With the application running, open Task Manager. You should see two processes one `Kolibri-0.18.1.exe` process and a `Kolibri` process. (`Kolibri-0.18.1.exe` is the server and `Kolibri` is the ui).
	2. Find the server subprocess (`Kolibri-0.18.1.exe`) and manually terminate it ("End Task").
	3. The main application window should remain open, but the webview will likely show a connection error. The UI itself should not crash.
	4. Now, close the main application window. It should close cleanly.

	Note: This PR does not include logic for the UI process to monitor the health of the server subprocess. If the server process crashes or is killed manually, it will **not** be automatically restarted. The UI window will remain open but will be unable to connect to Kolibri. This will be addressed in future PR related to the Windows Service.
	

**Testing on macOS/Linux (Regression Check):**
* Build and run the application on a non-Windows machine to confirm that there are no regressions. The behavior should be identical to the `main` branch.
* **Expected Behavior:** The application should start, load Kolibri, and shut down exactly as it does on the main branch. This refactoring should have introduced **no functional changes** on non-Windows platforms.