### PR TITLE
(windows): Upgrade to Edge WebView2 for web rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ Cross-platform Kolibri app
        - Run: `choco install wget`
        - In Git Bash, verify with: `wget --version`
 
+- **Microsoft Edge WebView2 Runtime:** Required on **Windows** for the application interface.
+    - This is pre-installed on most modern Windows systems.
+      - It can also be downloaded from the [official Microsoft website](https://developer.microsoft.com/en-us/Microsoft-edge/webview2/?form=MA13LH) (the "Evergreen Bootstrapper" is the easiest option).
+
 ### Supported Platforms
 
 - Linux

--- a/kolibri.spec
+++ b/kolibri.spec
@@ -1,6 +1,7 @@
 # -*- mode: python ; coding: utf-8 -*-
 import os
 import sys
+import wx
 
 from datetime import datetime
 from glob import glob
@@ -65,7 +66,9 @@ metadata.entry_points = monkey_patched_entry_points
 a = Analysis(
     [os.path.join('src', 'kolibri_app', '__main__.py')],
     pathex=['kolibrisrc', os.path.join('kolibrisrc', 'kolibri', 'dist')],
-    binaries=[],
+    binaries=[
+        (os.path.join(os.path.dirname(wx.__file__), 'WebView2Loader.dll'), '.')
+    ],
     datas=[('src/kolibri_app/assets', 'kolibri_app/assets')] + locale_datas,
     hiddenimports=['_cffi_backend'],
     hookspath=['hooks'],

--- a/kolibri.spec
+++ b/kolibri.spec
@@ -65,9 +65,11 @@ metadata.entry_points = monkey_patched_entry_points
 
 binaries_list = []
 if sys.platform == "win32":
-    binaries_list.append(
-        (os.path.join(os.path.dirname(wx.__file__), 'WebView2Loader.dll'), '.')
-    )
+    if os.path.exists(webview_dll_path):
+          binaries_list.append((webview_dll_path, '.'))
+    else:
+          print("WARNING: WebView2Loader.dll is missing,
+           WebView2 functionality will NOT work and app will fallback to using IE11.")
 
 a = Analysis(
     [os.path.join('src', 'kolibri_app', '__main__.py')],

--- a/kolibri.spec
+++ b/kolibri.spec
@@ -63,12 +63,16 @@ def monkey_patched_entry_points(**params):
 metadata.entry_points = monkey_patched_entry_points
 """.format(entry_point_packages))
 
+binaries_list = []
+if sys.platform == "win32":
+    binaries_list.append(
+        (os.path.join(os.path.dirname(wx.__file__), 'WebView2Loader.dll'), '.')
+    )
+
 a = Analysis(
     [os.path.join('src', 'kolibri_app', '__main__.py')],
     pathex=['kolibrisrc', os.path.join('kolibrisrc', 'kolibri', 'dist')],
-    binaries=[
-        (os.path.join(os.path.dirname(wx.__file__), 'WebView2Loader.dll'), '.')
-    ],
+    binaries=[binaries_list],
     datas=[('src/kolibri_app/assets', 'kolibri_app/assets')] + locale_datas,
     hiddenimports=['_cffi_backend'],
     hookspath=['hooks'],

--- a/kolibri.spec
+++ b/kolibri.spec
@@ -65,11 +65,14 @@ metadata.entry_points = monkey_patched_entry_points
 
 binaries_list = []
 if sys.platform == "win32":
-    if os.path.exists(webview_dll_path):
-          binaries_list.append((webview_dll_path, '.'))
+    dll_path = os.path.join(os.path.dirname(wx.__file__), 'WebView2Loader.dll')
+    if os.path.exists(dll_path):
+        binaries_list.append((dll_path, '.'))
     else:
-          print("WARNING: WebView2Loader.dll is missing,
-           WebView2 functionality will NOT work and app will fallback to using IE11.")
+        print(
+            "WARNING: WebView2Loader.dll is missing, "
+            "WebView2 functionality will NOT work and app will fallback to using IE11."
+        )
 
 a = Analysis(
     [os.path.join('src', 'kolibri_app', '__main__.py')],

--- a/kolibri.spec
+++ b/kolibri.spec
@@ -72,7 +72,7 @@ if sys.platform == "win32":
 a = Analysis(
     [os.path.join('src', 'kolibri_app', '__main__.py')],
     pathex=['kolibrisrc', os.path.join('kolibrisrc', 'kolibri', 'dist')],
-    binaries=[binaries_list],
+    binaries=binaries_list,
     datas=[('src/kolibri_app/assets', 'kolibri_app/assets')] + locale_datas,
     hiddenimports=['_cffi_backend'],
     hookspath=['hooks'],

--- a/src/kolibri_app/__main__.py
+++ b/src/kolibri_app/__main__.py
@@ -1,23 +1,11 @@
 import datetime
-import os
-import sys
 from multiprocessing import freeze_support
 
 from kolibri_app.application import KolibriApp
-from kolibri_app.constants import WINDOWS
 from kolibri_app.logger import logging
 
 
 def main():
-    if WINDOWS:
-        import winreg
-
-        root = winreg.ConnectRegistry(None, winreg.HKEY_CURRENT_USER)
-        KEY = r"SOFTWARE\Microsoft\Internet Explorer\Main\FeatureControl\FEATURE_BROWSER_EMULATION"
-        with winreg.CreateKeyEx(root, KEY, 0, winreg.KEY_ALL_ACCESS) as regkey:
-            winreg.SetValueEx(
-                regkey, os.path.basename(sys.executable), 0, winreg.REG_DWORD, 11000
-            )
     # Since the log files can contain multiple runs, make the first printout very visible to quickly show
     # when a new run starts in the log files.
     logging.info("Kolibri App Initializing")

--- a/src/kolibri_app/view.py
+++ b/src/kolibri_app/view.py
@@ -15,9 +15,6 @@ from kolibri_app.constants import WINDOWS
 from kolibri_app.i18n import _
 from kolibri_app.i18n import locale_info
 
-
-html2.WebView.MSWSetEmulationLevel(html2.WEBVIEWIE_EMU_IE11)
-
 LOADER_PAGE = "loading.html"
 
 ZOOM_LEVELS = [
@@ -63,7 +60,10 @@ class KolibriView(object):
         self.view = wx.Frame(None, -1, APP_NAME, size=size)
         self.view.SetMinSize((350, 400))
 
-        backend = html2.WebViewBackendDefault
+        if WINDOWS and html2.WebView.IsBackendAvailable(html2.WebViewBackendEdge):
+            backend = html2.WebViewBackendEdge
+        else:
+            backend = html2.WebViewBackendDefault
 
         self.webview = html2.WebView.New(self.view, backend=backend)
         self.webview.Bind(html2.EVT_WEBVIEW_NAVIGATING, self.OnBeforeLoad)


### PR DESCRIPTION
## Summary

This PR replaces the legacy IE-based web view with the modern, Chromium-based Edge WebView2 on Windows. Fixes UI unresponsiveness/crashes.

## References

Fixes #169

## Reviewer guidance
On a Windows machine with the WebView2 Runtime installed.
1. Run the PyInstaller build process (`make pyinstaller`)
2. Run the .exe file in dist/Kolibri-0.18.1/

**Expected Outcome:** The packaged application (.exe) should be noticable less laggy and should not crash or become unresponsive.