### PR TITLE
Implement Automated Build and Signing for Windows Installer

### DIFF
--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -111,13 +111,14 @@ jobs:
       run: |
         $baseName = (Get-ChildItem -Path dist-installer -Filter *.exe).BaseName
         $unsignedName = "$baseName-unsigned.exe"
-        $finalName = "$baseName.exe"
+        # The final name depends on whether this is a release build
+        $finalName = if ('${{ inputs.release }}' -eq 'true') { "$baseName.exe" } else { $unsignedName }
         # Rename the built file to have the "-unsigned" suffix
         Rename-Item -Path "dist-installer\$baseName.exe" -NewName $unsignedName
         echo "unsigned-exe-file-name=$unsignedName" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
         echo "final-exe-file-name=$finalName" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
 
-    - name: Sign files with Azure Trusted Signing
+    - name: Sign installer with Azure Trusted Signing
       if: ${{ inputs.release }}
       uses: azure/trusted-signing-action@v0
       with:
@@ -134,9 +135,10 @@ jobs:
         timestamp-digest: 'SHA256'
 
     - name: Prepare Final Artifact
+      if: ${{ inputs.release }}
       shell: pwsh
       run: |
-        # Always rename the file from "-unsigned.exe" to its final name before uploading.
+        # Only for a release, rename the file from "-unsigned.exe" to its final name after signing.
         Rename-Item -Path "dist-installer\${{ steps.get-exe-filename.outputs.unsigned-exe-file-name }}" -NewName "${{ steps.get-exe-filename.outputs.final-exe-file-name }}"
 
     - name: Upload installer artifact

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -1,0 +1,146 @@
+name: Build Windows installer
+
+on:
+  workflow_dispatch:
+    # Inputs the workflow accepts.
+    inputs:
+      whl-url:
+        description: 'URL for Kolibri whl file'
+        required: true
+      release:
+        description: 'Is this a release asset?'
+        required: false
+        type: boolean
+        default: false
+  workflow_call:
+    inputs:
+      whl-file-name:
+        required: false
+        type: string
+      whl-url:
+        required: false
+        type: string
+      ref:
+        description: 'A ref for this workflow to check out its own repo'
+        required: false
+        type: string
+      release:
+        description: 'Is this a release asset?'
+        required: false
+        type: boolean
+        default: false
+    secrets:
+      AZURE_TENANT_ID:
+        required: false
+      AZURE_CLIENT_ID:
+        required: false
+      AZURE_CLIENT_SECRET:
+        required: false
+    outputs:
+      exe-file-name:
+        description: "EXE file name"
+        value: ${{ jobs.build_exe.outputs.exe-file-name }}
+
+jobs:
+  build_exe:
+    name: Build EXE file
+    runs-on: windows-latest
+    outputs:
+      exe-file-name: ${{ steps.get-exe-filename.outputs.final-exe-file-name }}
+    steps:
+    - name: Validate whl reference inputs
+      if: ${{ (inputs.whl-file-name && inputs.whl-url) || (!inputs.whl-file-name && !inputs.whl-url) }}
+      run: |
+        echo "Must specify exactly one reference for the whl file to build the EXE with."
+        exit 1
+
+    - name: Check out code
+      uses: actions/checkout@v4
+      if: ${{ !inputs.ref }}
+
+    - name: Check out specific ref
+      uses: actions/checkout@v4
+      if: ${{ inputs.ref }}
+      with:
+        repository: learningequality/kolibri-app
+        ref: ${{ inputs.ref }}
+
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.10'
+
+    - name: Cache pip dependencies
+      uses: actions/cache@v4
+      with:
+        path: ~\AppData\Local\pip\Cache
+        key: ${{ runner.os }}-pip-${{ hashFiles('setup.py', 'build_requires.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-pip-
+
+    - name: Install build dependencies
+      run: make dependencies
+
+    - name: Install wget and Inno Setup
+      run: choco install wget innosetup --no-progress
+
+    - name: Download and install the whl from URL
+      if: ${{ inputs.whl-url }}
+      run: make get-whl whl=${{ inputs.whl-url }}
+
+    - name: Download the whl from artifacts
+      if: ${{ inputs.whl-file-name }}
+      uses: actions/download-artifact@v4
+      with:
+        name: ${{ inputs.whl-file-name }}
+        path: whl
+
+    - name: Install whl from artifacts
+      if: ${{ inputs.whl-file-name }}
+      run: make install-whl whl=whl/${{ inputs.whl-file-name }}
+
+    - name: Build the application with PyInstaller
+      run: make pyinstaller
+
+    - name: Build the Windows installer
+      run: make build-installer-windows
+
+    - name: Get EXE filenames
+      id: get-exe-filename
+      shell: pwsh
+      run: |
+        $baseName = (Get-ChildItem -Path dist-installer -Filter *.exe).BaseName
+        $unsignedName = "$baseName-unsigned.exe"
+        $finalName = "$baseName.exe"
+        # Rename the built file to have the "-unsigned" suffix
+        Rename-Item -Path "dist-installer\$baseName.exe" -NewName $unsignedName
+        echo "unsigned-exe-file-name=$unsignedName" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+        echo "final-exe-file-name=$finalName" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+
+    - name: Sign files with Azure Trusted Signing
+      if: ${{ inputs.release }}
+      uses: azure/trusted-signing-action@v0
+      with:
+        azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+        azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
+        azure-client-secret: ${{ secrets.AZURE_CLIENT_SECRET }}
+        endpoint: 'https://wus2.codesigning.azure.net/'
+        trusted-signing-account-name: 'LE-Trusted-Signing-Acct'
+        certificate-profile-name: 'LE-Windows-Certificates'
+        files-folder: dist-installer
+        files-folder-filter: ${{ steps.get-exe-filename.outputs.unsigned-exe-file-name }}
+        file-digest: SHA256
+        timestamp-rfc3161: 'http://timestamp.acs.microsoft.com'
+        timestamp-digest: 'SHA256'
+
+    - name: Prepare Final Artifact
+      shell: pwsh
+      run: |
+        # Always rename the file from "-unsigned.exe" to its final name before uploading.
+        Rename-Item -Path "dist-installer\${{ steps.get-exe-filename.outputs.unsigned-exe-file-name }}" -NewName "${{ steps.get-exe-filename.outputs.final-exe-file-name }}"
+
+    - name: Upload installer artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ steps.get-exe-filename.outputs.final-exe-file-name }}
+        path: dist-installer/${{ steps.get-exe-filename.outputs.final-exe-file-name }}

--- a/.github/workflows/pr_build.yml
+++ b/.github/workflows/pr_build.yml
@@ -1,4 +1,4 @@
-name: Build DMG for PRs
+name: Build Packages for PRs
 
 on:
   pull_request:
@@ -30,9 +30,18 @@ jobs:
             const whlUrl = whlAsset.browser_download_url;
             return whlUrl;
 
+  # Build macOS DMG
   build_dmg:
     name: Build Unsigned DMG
     needs: latest_kolibri_release
     uses: ./.github/workflows/build_mac.yml
+    with:
+      whl-url: ${{ needs.latest_kolibri_release.outputs.whl-url }}
+
+  # Build Windows installer
+  build_exe:
+    name: Build Unsigned EXE
+    needs: latest_kolibri_release
+    uses: ./.github/workflows/build_windows.yml
     with:
       whl-url: ${{ needs.latest_kolibri_release.outputs.whl-url }}

--- a/Makefile
+++ b/Makefile
@@ -137,6 +137,9 @@ else
 	@echo "Windows installer can only be built on Windows."
 endif
 
+# Default value for the signtool path
+SIGNTOOL_PATH ?= "C:\Program Files (x86)\Windows Kits\8.1\bin\x64\signtool.exe"
+
 # Code signing for the installer
 .PHONY: codesign-installer-windows
 codesign-installer-windows: build-installer-windows
@@ -144,7 +147,7 @@ codesign-installer-windows: build-installer-windows
 	$(MAKE) guard-WIN_CODESIGN_PWD
 	$(MAKE) guard-WIN_CODESIGN_CERT
 	# MSYS_NO_PATHCONV=1 prevents Git Bash/MINGW from converting option flags (like /f, /p) into file paths.
-	MSYS_NO_PATHCONV=1 "C:\Program Files (x86)\Windows Kits\8.1\bin\x64\signtool.exe" sign /f ${WIN_CODESIGN_PFX} /p ${WIN_CODESIGN_PWD} /ac ${WIN_CODESIGN_CERT} /tr http://timestamp.ssl.trustwave.com /td SHA256 /fd SHA256 "dist-installer/kolibri-setup-$(KOLIBRI_VERSION).exe"
+	MSYS_NO_PATHCONV=1 "$(SIGNTOOL_PATH)" sign /f ${WIN_CODESIGN_PFX} /p ${WIN_CODESIGN_PWD} /ac ${WIN_CODESIGN_CERT} /tr http://timestamp.ssl.trustwave.com /td SHA256 /fd SHA256 "dist-installer/kolibri-setup-$(KOLIBRI_VERSION).exe"
 
 compile-mo:
 	find src/kolibri_app/locales -name LC_MESSAGES -exec msgfmt {}/wxapp.po -o {}/wxapp.mo \;

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: clean get-whl install-whl clean-whl build-mac-app pyinstaller build-dmg compile-mo codesign-windows needs-version
+.PHONY: clean get-whl install-whl clean-whl build-mac-app pyinstaller build-dmg compile-mo needs-version
 
 ifeq ($(OS),Windows_NT)
     OSNAME := WIN32
@@ -137,26 +137,8 @@ else
 	@echo "Windows installer can only be built on Windows."
 endif
 
-# Default value for the signtool path
-SIGNTOOL_PATH ?= "C:\Program Files (x86)\Windows Kits\8.1\bin\x64\signtool.exe"
-
-# Code signing for the installer
-.PHONY: codesign-installer-windows
-codesign-installer-windows: build-installer-windows
-	$(MAKE) guard-WIN_CODESIGN_PFX
-	$(MAKE) guard-WIN_CODESIGN_PWD
-	$(MAKE) guard-WIN_CODESIGN_CERT
-	# MSYS_NO_PATHCONV=1 prevents Git Bash/MINGW from converting option flags (like /f, /p) into file paths.
-	MSYS_NO_PATHCONV=1 "$(SIGNTOOL_PATH)" sign /f ${WIN_CODESIGN_PFX} /p ${WIN_CODESIGN_PWD} /ac ${WIN_CODESIGN_CERT} /tr http://timestamp.ssl.trustwave.com /td SHA256 /fd SHA256 "dist-installer/kolibri-setup-$(KOLIBRI_VERSION).exe"
-
 compile-mo:
 	find src/kolibri_app/locales -name LC_MESSAGES -exec msgfmt {}/wxapp.po -o {}/wxapp.mo \;
-
-codesign-windows:
-	$(MAKE) guard-WIN_CODESIGN_PFX
-	$(MAKE) guard-WIN_CODESIGN_PWD
-	$(MAKE) guard-WIN_CODESIGN_CERT
-	C:\Program Files (x86)\Windows Kits\8.1\bin\x64\signtool.exe sign /f ${WIN_CODESIGN_PFX} /p ${WIN_CODESIGN_PWD} /ac ${WIN_CODESIGN_CERT} /tr http://timestamp.ssl.trustwave.com /td SHA256 /fd SHA256 dist/kolibri-${KOLIBRI_VERSION}.exe
 
 .PHONY: codesign-mac-app
 codesign-mac-app:


### PR DESCRIPTION
## Summary

This PR adds a GitHub Actions workflow to build and sign the Windows installer. It also updates the CI to build packages for both Windows and macOS on every pull request.

1. **New Windows Build Workflow (`build_windows.yml`):**
    * A self-contained workflow that automates the creation of the Windows `.exe` installer, handling dependency setup, PyInstaller bundling, and Inno Setup packaging.
2. **Automated Release Signing:**
    * The workflow integrates Azure Trusted Signing to automatically sign installers during release builds.
3. **Cross-Platform PR Validation (`pr_build.yml`):**
    * Pull request checks are updated to build both the macOS `.dmg` and Windows `.exe` installers in parallel.

## References

Fixes #187

## Reviewer guidance

This is a bit tricky.
As far as I understand, to be able to see a Git Action, the workflow has to be present in the main branch.

For this reason I used my main branch as the PR branch.

To test the changes, you'll need to manually trigger the workflow from my fork:
1. Navigate to the workflow page here: https://github.com/Dimi20cen/kolibri-app/actions/workflows/build_windows.yml.
2. Click the "Run workflow" dropdown button on the right and select the following:
	1. Use workflow from
		- Branch: main
	2. URL for Kolibri whl file
		- https://github.com/learningequality/kolibri/releases/download/v0.18.1/kolibri-0.18.1-py2.py3-none-any.whl
	3. Is this a release asset?
		- Leave it unchecked.
3. Wait for the workflow run to complete and confirm it succeeds.
4. Download the .exe installer artifact from the completed run.
5. Run the downloaded installer and verify that the application installs and launches correctly.
