### PR TITLE
Stop legacy cleanup from deleting new desktop shortcut

### DIFF
--- a/kolibri.iss
+++ b/kolibri.iss
@@ -153,17 +153,6 @@ begin
   end
   else
     Log('Legacy application uninstall key not found. No cleanup needed.');
-
-  // Clean up legacy desktop shortcut, if it exists.
-  if FileExists(ExpandConstant('{commondesktop}\Kolibri.lnk')) then
-  begin
-    Log('Deleting legacy desktop shortcut...');
-    if DeleteFile(ExpandConstant('{commondesktop}\Kolibri.lnk')) then
-        Log('Successfully deleted legacy desktop shortcut.')
-    else
-        Log('WARNING: Failed to delete legacy desktop shortcut.');
-  end;
-
   Log('Forceful legacy cleanup finished.');
 end;
 

--- a/kolibri.iss
+++ b/kolibri.iss
@@ -476,6 +476,24 @@ begin
       // Remove from startup if exists
       RegDeleteValue(HKLM, 'SOFTWARE\Microsoft\Windows\CurrentVersion\Run', 'KolibriTray');
     end;
+
+    // Handle the desktop icon based on user selection during upgrades/repairs.
+    if not WizardIsTaskSelected('desktopicon') then
+    begin
+      if FileExists(ExpandConstant('{commondesktop}\Kolibri.lnk')) then
+      begin
+        Log('User opted not to create a desktop icon. Removing existing shortcut.');
+        if DeleteFile(ExpandConstant('{commondesktop}\Kolibri.lnk')) then
+            Log('Successfully removed the old desktop shortcut.')
+        else
+            Log('WARNING: Failed to delete the old desktop shortcut.');
+      end;
+    end
+    else
+    begin
+        // If the user checked the box, the [Icons] section will create/overwrite it.
+        Log('User opted to create a desktop icon. The [Icons] section will manage it.');
+    end;
   end;
 end;
 


### PR DESCRIPTION
## Summary

The post-install script was deleting the `Kolibri.lnk` shortcut it had just created, assuming it was a leftover from a legacy installation.

This change comments out the legacy shortcut deletion code to ensure the icon persists as expected.

## References
Fixes issue introduced in PR #186 

## Reviewer guidance
1. Download and run the legacy kolibri installer from [here](https://learningequality.org/r/kolibri-windows-setup-latest).

2. Download and run the new installer created by Git Action: Build Unsigned EXE
   - Make sure to check the "Create a desktop shortcut" option during installation.

**Verify:** After the installation of the new app the kolibri destop shortcut should be present on your desktop and it should opens kolibri as expected.

> [!NOTE] 
>Currently when the "Create a desktop shortcut" option is not checked during installation, but a destop shortcut is created from a previous installation it doesn't get deleted. 
If you think it's better that we change that please let me know.